### PR TITLE
allow log handle to be provided

### DIFF
--- a/src/Dex.jl
+++ b/src/Dex.jl
@@ -60,11 +60,10 @@ function setup(ctx::DexCtx, configfile::String, templates::Union{String,Nothing}
     nothing
 end
 
-function start(ctx::DexCtx)
+function start(ctx::DexCtx; log=logfile(ctx), append::Bool=isa(log,AbstractString))
     config = conffile(ctx)
     command = Cmd(`$dex serve $config`; detach=true, dir=ctx.workdir)
-    log = logfile(ctx)
-    redirected_command = pipeline(command, stdout=log, stderr=log, append=true)
+    redirected_command = pipeline(command, stdout=log, stderr=log, append=append)
     ctx.proc = run(redirected_command; wait=false)
     ctx.pid = getpid(ctx.proc)
     open(joinpath(logsdir(ctx), "dex.pid"), "a") do file

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,6 +98,22 @@ function test()
     @test !isrunning(dex)
     @test isfile(Dex.logfile(dex))
 
+    @info("starting Dex (with custom logger)")
+    pipe = PipeBuffer()
+    start(dex; log=pipe)
+    sleep(2)
+    @test isfile(Dex.pidfile(dex))
+    @test isrunning(dex)
+
+    @info("stopping Dex (with custom logger)")
+    stop(dex)
+    sleep(2)
+    @test !isfile(Dex.pidfile(dex))
+    @test !isrunning(dex)
+    logbytes = readavailable(pipe)
+    @test !isempty(logbytes)
+    @test findfirst("listening", String(logbytes)) !== nothing
+
     @test_throws Exception setup(dex, cfgfile)
     @test nothing === setup(dex, cfgfile; force=true)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,6 +67,10 @@ end
 
 function test()
     workdir = mktempdir()
+
+    dex = DexCtx(workdir)
+    @test !isrunning(dex)
+
     mkpath(workdir)
     cfgfile = createconfig(workdir)
     dex = DexCtx(workdir)
@@ -104,6 +108,10 @@ function test()
     sleep(2)
     @test isfile(Dex.pidfile(dex))
     @test isrunning(dex)
+
+    @info("checking new DexCtx")
+    dex2 = DexCtx(workdir)
+    @test isrunning(dex2)
 
     @info("stopping Dex (with custom logger)")
     stop(dex)


### PR DESCRIPTION
Accept optional parameters in the `start` method through which the caller can provide a handle to write logs into.

```julia
function start(ctx::DexCtx; log=logfile(ctx), append::Bool=isa(log,AbstractString))
    # log: can point to an IO object or a filename
    # append: should be set to false if an IO object is provided for loging
end
```