### PR TITLE
update to use Dex_jll 2.28

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,14 +3,14 @@ uuid = "90177ba7-a91c-5852-bc95-36ac82816823"
 keywords = ["dex", "julia"]
 license = "MIT"
 desc = "Launch and manage Dex from Julia"
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 Dex_jll = "f1ef5e10-671a-599f-ac25-3c68827556ba"
 
 [compat]
-julia = "1.3,1.4,1.5"
-Dex_jll = "2.27"
+julia = "1.3"
+Dex_jll = "2.28"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Update to use Dex_jll 2.28 with patch to allow multiple refresh tokens.
Also bump patch version.